### PR TITLE
Bug 930948 - [Flatfish] marionette test on tablet

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -15,6 +15,17 @@ function buildArgv(options) {
     argv.push(options.profile);
   }
 
+  if (options.pref.screen &&
+      options.pref.screen.width &&
+      options.pref.screen.height) {
+
+    argv.push('--screen=' +
+      options.pref.screen.width + 'x' +
+      options.pref.screen.height + (
+        options.pref.screen.dpi ?
+          ('@' + options.pref.screen.dpi) :
+          ''));
+  }
 
   if (options.noRemote !== false)
     argv.push('-no-remote');


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=930948

we can assign the screen size as below.
var client = marionette.client({
    screen: {
    width: 1280,
    height: 800
  }});
