### PR TITLE
Bug 930948 - [Flatfish] marionette test on tablet

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -15,6 +15,18 @@ function buildArgv(options) {
     argv.push(options.profile);
   }
 
+  if (options.runner &&
+      options.runner.screen &&
+      options.runner.screen.width &&
+      options.runner.screen.height) {
+
+    argv.push('--screen=' +
+      options.runner.screen.width + 'x' +
+      options.runner.screen.height + (
+        options.runner.screen.dpi ?
+          ('@' + options.runner.screen.dpi) :
+          ''));
+  }
 
   if (options.noRemote !== false)
     argv.push('-no-remote');

--- a/test/run.js
+++ b/test/run.js
@@ -28,6 +28,36 @@ suite('run', function() {
     });
   });
 
+  test('launch firefox with different screen', function(done) {
+    var profileDir = __dirname + '/fixtures/profile';
+    var options =
+      { product: 'firefox', profile: profileDir,
+        runner: {
+          screen: {
+            width: 1280,
+            height: 800,
+            dpi: 160
+          }
+        }};
+    this.timeout(5000);
+    run(runtime, options, function(err, child, bin, argv) {
+      assert.ok(!err, err && err.message);
+
+      // verify screen size
+      assert.deepEqual(
+        argv,
+        [
+          '-profile', profileDir, '--screen=1280x800@160',
+          '-no-remote'
+        ]
+      );
+
+      // verify we have a child
+      assert.ok(child.kill, 'is process');
+      child.kill();
+      done();
+    });
+  });
   suite('launch firefox read dump', function() {
     var server;
     var port = 60033;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=930948

we can assign the screen size as below.
var client = marionette.client({hostOptions:{
screen: {
width: 1280,
height: 800
}}});
